### PR TITLE
Add minimal Flask prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.idea/
+.DS_Store
+webapp/__pycache__/
+webapp/*.pyc
+newwebapp/venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# CT Install App
+
+This repository contains a minimal prototype for a CT scanner installation project management system. It demonstrates:
+
+- A Flask web app with a simple scanner model comparator.
+- An engineer-only conformity check using the OpenAI API.
+
+The web app code lives in `webapp/`. To run it, install dependencies and start the server:
+
+```bash
+pip install -r webapp/requirements.txt
+python webapp/app.py
+```
+
+Set the `OPENAI_API_KEY` environment variable to enable AI responses.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,54 @@
+from flask import Flask, render_template, request
+import os
+import openai
+
+app = Flask(__name__)
+
+# Simple in-memory model database
+MODELS = {
+    'NeuViz ACE': {
+        'door_width': 1200,
+        'power_kva': 50,
+        'room_height': 250,
+    },
+    'Brand X': {
+        'door_width': 1100,
+        'power_kva': 60,
+        'room_height': 260,
+    },
+}
+
+@app.route('/')
+def index():
+    return render_template('index.html', models=MODELS.keys())
+
+@app.route('/compare', methods=['POST'])
+def compare():
+    m1 = request.form.get('model1')
+    m2 = request.form.get('model2')
+    model1 = MODELS.get(m1)
+    model2 = MODELS.get(m2)
+    return render_template('compare.html', m1=m1, m2=m2, model1=model1, model2=model2)
+
+@app.route('/conformity', methods=['GET', 'POST'])
+def conformity():
+    result = None
+    if request.method == 'POST':
+        door_width = request.form.get('door_width')
+        power_kva = request.form.get('power_kva')
+        room_height = request.form.get('room_height')
+        prompt = f"Door width: {door_width} mm\nPower: {power_kva} kVA\nRoom height: {room_height} cm\n" \
+                 "Check compliance with requirements: door >=1200mm, power>=50kVA, room height>=250cm."
+        openai.api_key = os.getenv('OPENAI_API_KEY')
+        try:
+            resp = openai.ChatCompletion.create(
+                model='gpt-3.5-turbo',
+                messages=[{'role':'user','content':prompt}]
+            )
+            result = resp.choices[0].message['content']
+        except Exception as e:
+            result = f"Error contacting OpenAI: {e}"
+    return render_template('conformity.html', result=result)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,2 @@
+flask
+openai

--- a/webapp/templates/compare.html
+++ b/webapp/templates/compare.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head><title>Model Comparison</title></head>
+<body>
+<h2>Compare {{m1}} vs {{m2}}</h2>
+<table border="1">
+<tr><th>Parameter</th><th>{{m1}}</th><th>{{m2}}</th></tr>
+<tr><td>Door width (mm)</td><td>{{model1.door_width}}</td><td>{{model2.door_width}}</td></tr>
+<tr><td>Power (kVA)</td><td>{{model1.power_kva}}</td><td>{{model2.power_kva}}</td></tr>
+<tr><td>Room height (cm)</td><td>{{model1.room_height}}</td><td>{{model2.room_height}}</td></tr>
+</table>
+<a href="/">Home</a>
+</body>
+</html>

--- a/webapp/templates/conformity.html
+++ b/webapp/templates/conformity.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head><title>Conformity Check</title></head>
+<body>
+<h2>Conformity Check</h2>
+<form method="post">
+<label>Door width (mm): <input name="door_width"></label><br>
+<label>Power (kVA): <input name="power_kva"></label><br>
+<label>Room height (cm): <input name="room_height"></label><br>
+<button type="submit">Run Check</button>
+</form>
+{% if result %}<h3>Result</h3><pre>{{result}}</pre>{% endif %}
+<a href="/">Home</a>
+</body>
+</html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head><title>CT Install Manager</title></head>
+<body>
+<h1>CT Install Manager</h1>
+<form action="/compare" method="post">
+    <h2>Model Comparison</h2>
+    <select name="model1">
+        {% for m in models %}<option value="{{m}}">{{m}}</option>{% endfor %}
+    </select>
+    <select name="model2">
+        {% for m in models %}<option value="{{m}}">{{m}}</option>{% endfor %}
+    </select>
+    <button type="submit">Compare</button>
+</form>
+<hr>
+<a href="/conformity">Run Conformity Check</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple Flask app with AI conformity checker and model comparison
- document running the prototype
- ignore virtual environment files

## Testing
- `pip install -r webapp/requirements.txt`
- `python webapp/app.py` (verified server started)

------
https://chatgpt.com/codex/tasks/task_e_686718d4b5e8832c97360fa66d1c1807